### PR TITLE
[main] Update AL-Go System Files - 4f808388705483cddebb2baf115256321d55bdc7

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -28,11 +28,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -32,11 +32,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,6 +1,6 @@
 {
   "type": "PTE",
-  "templateUrl": "https://github.com/freddydk/AL-Go@releasenotes",
+  "templateUrl": "https://github.com/microsoft/AL-Go-PTE@preview",
   "currentSchedule": "0 2 * * 1,2,3,4,5",
   "NextMinorSchedule": "0 2 * * 6",
   "NextMajorSchedule": "0 2 * * 0",
@@ -17,5 +17,5 @@
   "DeployToDIRPROD": {
     "continuousDeployment": false
   },
-  "templateSha": "881a7e72966d7ded02f4f0b0d487749127643a73"
+  "templateSha": "4f808388705483cddebb2baf115256321d55bdc7"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,167 @@
+## v5.2
+
+### Issues
+- Issue 1084 Automatic updates for AL-Go are failing when main branch requires Pull Request
+
+### New Settings
+
+- `PowerPlatformSolutionFolder`: Contains the name of the folder containing a PowerPlatform Solution (only one)
+- `DeployTo<environment>` now has two additional properties `companyId` is the Company Id from Business Central (for PowerPlatform connection) and `ppEnvironmentUrl` is the Url of the PowerPlatform environment to deploy to.
+
+### New Actions
+
+- `BuildPowerPlatform`: to build a PowerPlatform Solution
+- `DeployPowerPlatform`: to deploy a PowerPlatform Solution
+- `PullPowerPlatformChanges`: to pull changes made in PowerPlatform studio into the repository
+- `ReadPowerPlatformSettings`: to read settings and secrets for PowerPlatform deployment
+- `GetArtifactsForDeployment`: originally code from deploy.ps1 to retrieve artifacts for releases or builds - now as an action to read apps into a folder.
+
+### New Workflows
+
+- **Pull PowerPlatform Changes** for pulling changes from your PowerPlatform development environment into your AL-Go for GitHub repository
+- **Push PowerPlatform Changes** for pushing changes from your AL-Go for GitHub repository to your PowerPlatform development environment
+
+> [!NOTE]
+> PowerPlatform workflows are only available in the PTE template and will be removed if no PowerPlatformSolutionFolder is defined in settings.
+
+### New Scenarios (Documentation)
+
+- [Connect your GitHub repository to Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupPowerPlatform.md)
+- [How to set up Service Principal for Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupServicePrincipalForPowerPlatform.md)
+- [Try one of the Business Central and Power Platform samples](https://github.com/microsoft/AL-Go/blob/main/Scenarios/TryPowerPlatformSamples.md)
+- [Publish To AppSource](https://github.com/microsoft/AL-Go/blob/main/Scenarios/PublishToAppSource.md)
+
+> [!NOTE]
+> PowerPlatform functionality are only available in the PTE template.
+
+## v5.1
+
+### Issues
+
+- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
+- Issue 1021 Error during Create Online Development Environment action
+- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
+- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
+- ContainerName used during build was invalid if project names contained special characters
+- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
+- Issue 997 'Deliver to AppSource' action fails for projects containing a space
+- Issue 987 Resource not accessible by integration when creating release from specific version
+- Issue 979 Publish to AppSource Documentation
+- Issue 1018 Artifact setting - possibility to read version from app.json
+- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
+- Issue 962 Finer control of "shell"-property
+- Issue 1041 Harden the version comparison when incrementing version number
+- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes
+
+### Better artifact selection
+
+The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.
+- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+
+### New Settings
+
+- `deliverToAppSource`: a JSON object containing the following properties
+  - **productId** must be the product Id from partner Center.
+  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
+  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
+  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
+- Add `shell` as a property under `DeployTo` structure
+
+### Deprecated Settings
+
+- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
+- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
+- `appSourceProductId` is moved to the `deliverToAppSource` structure
+
+### New parameter -clean on localdevenv and clouddevenv
+
+Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.
+
+## v5.0
+
+### Issues
+- Issue 940 Publish to Environment is broken when specifying projects to publish
+- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories
+
+### New Settings
+- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.
+
+### Issues
+- Support release branches that start with releases/
+- Issue 870 Improve Error Handling when CLI is missing
+- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
+- Issue 973 Prerelease is not used for deployment
+
+### Build modes
+AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.
+
+## v4.1
+
+### New Settings
+- `templateSha`: The SHA of the version of AL-Go currently used
+
+### New Actions
+- `DumpWorkflowInfo`: Dump information about running workflow
+- `Troubleshooting` : Run troubleshooting for repository
+
+### Update AL-Go System Files
+Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
+If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.
+
+### Issues
+- Issue 782 Exclude '.altestrunner/' from template .gitignore
+- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
+- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
+- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
+- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction
+
+### New Settings
+
+- `alDoc` : JSON object with properties for the ALDoc reference document generation
+  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
+  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
+  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
+  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
+  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
+  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
+  - **header** = Header for the documentation site. (Default: Documentation for...)
+  - **footer** = Footer for the documentation site. (Default: Made with...)
+  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
+  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
+  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*
+
+### New Workflows
+- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
+- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.
+
+### Support for ALDoc reference documentation tool
+ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.
+
+## v4.0
+
+### Removal of the InsiderSasToken
+
+As of October 1st 2023, Business Central insider builds are now publicly available. When creating local containers with the insider builds, you will have to accept the insider EULA (https://go.microsoft.com/fwlink/?linkid=2245051) in order to continue.
+
+AL-Go for GitHub allows you to build and test using insider builds without any explicit approval, but please note that the insider artifacts contains the insider Eula and you automatically accept this when using the builds.
+
+### Issues
+- Issue 730 Support for external rulesets.
+- Issue 739 Workflow specific KeyVault settings doesn't work for localDevEnv
+- Using self-hosted runners while using Azure KeyVault for secrets or signing might fail with C:\Modules doesn't exist
+- PullRequestHandler wasn't triggered if only .md files where changes. This lead to PRs which couldn't be merged if a PR status check was mandatory.
+- Artifacts names for PR Builds were using the merge branch instead of the head branch.
+
+### New Settings
+- `enableExternalRulesets`: set this setting to true if you want to allow AL-Go to automatically download external references in rulesets.
+- `deliverTo<deliveryTarget>`: is not really new, but has new properties and wasn't documented. The complete list of properties is here (note that some properties are deliveryTarget specific):
+  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default [ "main" ])
+  - **CreateContainerIfNotExist** = *[Only for DeliverToStorage]* Create Blob Storage Container if it doesn't already exist. (Default false)
+
+### Deployment
+Environment URL is now displayed underneath the environment being deployed to in the build summary. For Custom Deployment, the script can set the GitHub Output variable `environmentUrl` in order to show a custom URL.
+
 ## v3.3
 
 ### Issues

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -48,19 +48,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0090"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -68,7 +68,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: freddydk/AL-Go/Actions/AddExistingApp@releasenotes
+        uses: microsoft/AL-Go-Actions/AddExistingApp@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0090"

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -44,7 +44,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -55,14 +55,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
           get: type, powerPlatformSolutionFolder
@@ -74,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: freddydk/AL-Go/Actions/DetermineDeliveryTargets@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v5.2
         with:
           shell: pwsh
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: freddydk/AL-Go/Actions/DetermineDeliveryTargets@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -113,7 +113,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: freddydk/AL-Go/Actions/DetermineDeploymentEnvironments@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -129,13 +129,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: freddydk/AL-Go/Actions/CheckForUpdates@releasenotes
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.2
         with:
           shell: pwsh
           templateUrl: ${{ env.templateUrl }}
@@ -188,7 +188,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build Reference Documentation
-        uses: freddydk/AL-Go/Actions/BuildReferenceDocumentation@releasenotes
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v5.2
         with:
           shell: pwsh
           artifacts: '.artifacts'
@@ -234,7 +234,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -248,7 +248,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -256,7 +256,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: freddydk/AL-Go/Actions/Deploy@releasenotes
+        uses: microsoft/AL-Go-Actions/Deploy@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -268,7 +268,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: freddydk/AL-Go/Actions/DeployPowerPlatform@releasenotes
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -296,20 +296,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: freddydk/AL-Go/Actions/Deliver@releasenotes
+        uses: microsoft/AL-Go-Actions/Deliver@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -329,7 +329,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0091"

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -58,20 +58,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0092"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: freddydk/AL-Go/Actions/CreateApp@releasenotes
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0092"

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -48,7 +48,7 @@ jobs:
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -57,20 +57,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0093"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -83,17 +83,17 @@ jobs:
           $settings = $env:Settings | ConvertFrom-Json
           if ('${{ fromJson(steps.ReadSecrets.outputs.Secrets).adminCenterApiCredentials }}') {
             Write-Host "AdminCenterApiCredentials provided in secret $($settings.adminCenterApiCredentialsSecretName)!"
-            Add-Content -Encoding UTF8 -path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($settings.adminCenterApiCredentialsSecretName). Using this information for authentication."
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($settings.adminCenterApiCredentialsSecretName). Using this information for authentication."
           }
           else {
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
-            Add-Content -Encoding UTF8 -path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($settings.adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($settings.adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
             Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
@@ -111,13 +111,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,7 +136,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: freddydk/AL-Go/Actions/CreateDevelopmentEnvironment@releasenotes
+        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0093"

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -64,19 +64,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0102"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -84,7 +84,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: freddydk/AL-Go/Actions/CreateApp@releasenotes
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0102"

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -72,7 +72,7 @@ jobs:
       releaseVersion: ${{ steps.createreleasenotes.outputs.releaseVersion }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -81,21 +81,21 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0094"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
           get: templateUrl,repoName,type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -104,12 +104,12 @@ jobs:
   
       - name: Determine Projects
         id: determineProjects
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
 
       - name: Check for updates to AL-Go system files
-        uses: freddydk/AL-Go/Actions/CheckForUpdates@releasenotes
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.2
         with:
           shell: pwsh
           templateUrl: ${{ env.templateUrl }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: freddydk/AL-Go/Actions/CreateReleaseNotes@releasenotes
+        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v5.2
         with:
           shell: pwsh
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -246,13 +246,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -290,7 +290,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: freddydk/AL-Go/Actions/Deliver@releasenotes
+        uses: microsoft/AL-Go-Actions/Deliver@v5.2
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -303,7 +303,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: freddydk/AL-Go/Actions/Deliver@releasenotes
+        uses: microsoft/AL-Go-Actions/Deliver@v5.2
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -347,13 +347,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -361,7 +361,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: freddydk/AL-Go/Actions/IncrementVersionNumber@releasenotes
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -379,7 +379,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0094"

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -60,19 +60,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0095"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -80,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: freddydk/AL-Go/Actions/CreateApp@releasenotes
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0095"

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -32,7 +32,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -43,14 +43,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0101"

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,19 +30,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0097"
         
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: freddydk/AL-Go/Actions/DetermineDeploymentEnvironments@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/configure-pages@v5
         
       - name: Build Reference Documentation
-        uses: freddydk/AL-Go/Actions/BuildReferenceDocumentation@releasenotes
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v5.2
         with:
           shell: pwsh
           artifacts: 'latest'

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -48,19 +48,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0096"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -68,7 +68,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: freddydk/AL-Go/Actions/IncrementVersionNumber@releasenotes
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v5.2
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0096"

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -32,7 +32,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -43,14 +43,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0099"

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -32,7 +32,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -43,14 +43,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: pwsh
           eventId: "DO0100"

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -35,7 +35,7 @@ jobs:
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -44,20 +44,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: freddydk/AL-Go/Actions/DetermineDeploymentEnvironments@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: pwsh
@@ -101,17 +101,17 @@ jobs:
           }
           if ($authContext) {
             Write-Host "AuthContext provided in secret $secretName!"
-            Add-Content -Encoding UTF8 -path $ENV:GITHUB_STEP_SUMMARY -value "AuthContext was provided in a secret called $secretName. Using this information for authentication."
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AuthContext was provided in a secret called $secretName. Using this information for authentication."
           }
           else {
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/freddydk/AL-Go/releasenotes/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.2/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
-            Add-Content -Encoding UTF8 -path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
             Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
           }
 
@@ -141,29 +141,29 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: Get Artifacts for deployment
-        uses: freddydk/AL-Go/Actions/GetArtifactsForDeployment@releasenotes
+        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v5.2
         with:
-          shell: ${{ matrix.shell }}
+          shell: pwsh
           artifactsVersion: ${{ github.event.inputs.appVersion }}
           artifactsFolder: '.artifacts'
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: freddydk/AL-Go/Actions/Deploy@releasenotes
+        uses: microsoft/AL-Go-Actions/Deploy@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -175,11 +175,11 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: freddydk/AL-Go/Actions/DeployPowerPlatform@releasenotes
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
-          shell: ${{ matrix.shell }}
+          shell: pwsh
           environmentName: ${{ matrix.environment }}
           artifactsFolder: '.artifacts'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
@@ -194,8 +194,8 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
-          shell: ${{ matrix.shell }}
+          shell: pwsh
           eventId: "DO0097"
           telemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -27,7 +27,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: freddydk/AL-Go/Actions/VerifyPRChanges@releasenotes
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v5.2
 
   Initialization:
     needs: [ PregateCheck ]
@@ -44,7 +44,7 @@ jobs:
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: pwsh
 
@@ -56,14 +56,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: pwsh
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: pwsh
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: freddydk/AL-Go/Actions/DetermineProjectsToBuild@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.2
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: freddydk/AL-Go/Actions/PullRequestStatusCheck@releasenotes
+        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v5.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: freddydk/AL-Go/Actions/Troubleshooting@releasenotes
+        uses: microsoft/AL-Go-Actions/Troubleshooting@v5.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       templateUrl:
-        description: Template Repository URL (current is https://github.com/freddydk/AL-Go@releasenotes)
+        description: Template Repository URL (current is https://github.com/microsoft/AL-Go-PTE@preview)
         required: false
         default: ''
       downloadLatest:
@@ -34,7 +34,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: freddydk/AL-Go/Actions/DumpWorkflowInfo@releasenotes
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.2
         with:
           shell: powershell
 
@@ -43,20 +43,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: freddydk/AL-Go/Actions/WorkflowInitialize@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.2
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -92,7 +92,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: freddydk/AL-Go/Actions/CheckForUpdates@releasenotes
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.2
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: freddydk/AL-Go/Actions/WorkflowPostProcess@releasenotes
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.2
         with:
           shell: powershell
           eventId: "DO0098"

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -96,7 +96,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: freddydk/AL-Go/Actions/ReadSettings@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -105,14 +105,14 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: github.event_name != 'pull_request'
-        uses: freddydk/AL-Go/Actions/ReadSecrets@releasenotes
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.2
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
 
       - name: Determine ArtifactUrl
-        uses: freddydk/AL-Go/Actions/DetermineArtifactUrl@releasenotes
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v5.2
         id: determineArtifactUrl
         with:
           shell: ${{ inputs.shell }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
-        uses: freddydk/AL-Go/Actions/DownloadProjectDependencies@releasenotes
+        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -139,7 +139,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: freddydk/AL-Go/Actions/RunPipeline@releasenotes
+        uses: microsoft/AL-Go-Actions/RunPipeline@v5.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
           BuildMode: ${{ inputs.buildMode }}
@@ -155,7 +155,7 @@ jobs:
       - name: Sign
         if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
         id: sign
-        uses: freddydk/AL-Go/Actions/Sign@releasenotes
+        uses: microsoft/AL-Go-Actions/Sign@v5.2
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
@@ -164,7 +164,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: freddydk/AL-Go/Actions/CalculateArtifactNames@releasenotes
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v5.2
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -258,7 +258,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: (success() || failure()) && env.doNotRunTests == 'False'
-        uses: freddydk/AL-Go/Actions/AnalyzeTests@releasenotes
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v5.2
         with:
           shell: ${{ inputs.shell }}
           parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: freddydk/AL-Go/Actions/PipelineCleanup@releasenotes
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@v5.2
         with:
           shell: ${{ inputs.shell }}
           parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}


### PR DESCRIPTION
## microsoft/AL-Go-PTE@preview

## v5.2

### Issues
- Issue 1084 Automatic updates for AL-Go are failing when main branch requires Pull Request

### New Settings

- `PowerPlatformSolutionFolder`: Contains the name of the folder containing a PowerPlatform Solution (only one)
- `DeployTo<environment>` now has two additional properties `companyId` is the Company Id from Business Central (for PowerPlatform connection) and `ppEnvironmentUrl` is the Url of the PowerPlatform environment to deploy to.

### New Actions

- `BuildPowerPlatform`: to build a PowerPlatform Solution
- `DeployPowerPlatform`: to deploy a PowerPlatform Solution
- `PullPowerPlatformChanges`: to pull changes made in PowerPlatform studio into the repository
- `ReadPowerPlatformSettings`: to read settings and secrets for PowerPlatform deployment
- `GetArtifactsForDeployment`: originally code from deploy.ps1 to retrieve artifacts for releases or builds - now as an action to read apps into a folder.

### New Workflows

- **Pull PowerPlatform Changes** for pulling changes from your PowerPlatform development environment into your AL-Go for GitHub repository
- **Push PowerPlatform Changes** for pushing changes from your AL-Go for GitHub repository to your PowerPlatform development environment

> [!NOTE]
> PowerPlatform workflows are only available in the PTE template and will be removed if no PowerPlatformSolutionFolder is defined in settings.

### New Scenarios (Documentation)

- [Connect your GitHub repository to Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupPowerPlatform.md)
- [How to set up Service Principal for Power Platform](https://github.com/microsoft/AL-Go/blob/main/Scenarios/SetupServicePrincipalForPowerPlatform.md)
- [Try one of the Business Central and Power Platform samples](https://github.com/microsoft/AL-Go/blob/main/Scenarios/TryPowerPlatformSamples.md)
- [Publish To AppSource](https://github.com/microsoft/AL-Go/blob/main/Scenarios/PublishToAppSource.md)

> [!NOTE]
> PowerPlatform functionality are only available in the PTE template.

## v5.1

### Issues

- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
- Issue 1021 Error during Create Online Development Environment action
- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
- ContainerName used during build was invalid if project names contained special characters
- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
- Issue 997 'Deliver to AppSource' action fails for projects containing a space
- Issue 987 Resource not accessible by integration when creating release from specific version
- Issue 979 Publish to AppSource Documentation
- Issue 1018 Artifact setting - possibility to read version from app.json
- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
- Issue 962 Finer control of "shell"-property
- Issue 1041 Harden the version comparison when incrementing version number
- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes

### Better artifact selection

The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.
- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.

### New Settings

- `deliverToAppSource`: a JSON object containing the following properties
  - **productId** must be the product Id from partner Center.
  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
- Add `shell` as a property under `DeployTo` structure

### Deprecated Settings

- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
- `appSourceProductId` is moved to the `deliverToAppSource` structure

### New parameter -clean on localdevenv and clouddevenv

Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.

## v5.0

### Issues
- Issue 940 Publish to Environment is broken when specifying projects to publish
- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories

### New Settings
- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.

### Issues
- Support release branches that start with releases/
- Issue 870 Improve Error Handling when CLI is missing
- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
- Issue 973 Prerelease is not used for deployment

### Build modes
AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.

## v4.1

### New Settings
- `templateSha`: The SHA of the version of AL-Go currently used

### New Actions
- `DumpWorkflowInfo`: Dump information about running workflow
- `Troubleshooting` : Run troubleshooting for repository

### Update AL-Go System Files
Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.

### Issues
- Issue 782 Exclude '.altestrunner/' from template .gitignore
- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction

### New Settings

- `alDoc` : JSON object with properties for the ALDoc reference document generation
  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
  - **header** = Header for the documentation site. (Default: Documentation for...)
  - **footer** = Footer for the documentation site. (Default: Made with...)
  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*

### New Workflows
- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.

### Support for ALDoc reference documentation tool
ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.

## v4.0

### Removal of the InsiderSasToken

As of October 1st 2023, Business Central insider builds are now publicly available. When creating local containers with the insider builds, you will have to accept the insider EULA (https://go.microsoft.com/fwlink/?linkid=2245051) in order to continue.

AL-Go for GitHub allows you to build and test using insider builds without any explicit approval, but please note that the insider artifacts contains the insider Eula and you automatically accept this when using the builds.

### Issues
- Issue 730 Support for external rulesets.
- Issue 739 Workflow specific KeyVault settings doesn't work for localDevEnv
- Using self-hosted runners while using Azure KeyVault for secrets or signing might fail with C:\Modules doesn't exist
- PullRequestHandler wasn't triggered if only .md files where changes. This lead to PRs which couldn't be merged if a PR status check was mandatory.
- Artifacts names for PR Builds were using the merge branch instead of the head branch.

### New Settings
- `enableExternalRulesets`: set this setting to true if you want to allow AL-Go to automatically download external references in rulesets.
- `deliverTo<deliveryTarget>`: is not really new, but has new properties and wasn't documented. The complete list of properties is here (note that some properties are deliveryTarget specific):
  - **Branches** = an array of branch patterns, which are allowed to deliver to this deliveryTarget. (Default [ "main" ])
  - **CreateContainerIfNotExist** = *[Only for DeliverToStorage]* Create Blob Storage Container if it doesn't already exist. (Default false)

### Deployment
Environment URL is now displayed underneath the environment being deployed to in the build summary. For Custom Deployment, the script can set the GitHub Output variable `environmentUrl` in order to show a custom URL.
